### PR TITLE
fix(cloudfront): guard WAF web_acl_id reference behind services.waf.enabled

### DIFF
--- a/templates/terraform/aws/cloudfront.tf
+++ b/templates/terraform/aws/cloudfront.tf
@@ -43,7 +43,9 @@ module "cloudfront_distributions" {
     restriction_type = "none"
   }
 
+  # @section services.waf.enabled begin
   web_acl_id = var.cloudfront_enable_waf ? try(aws_wafv2_web_acl.waf, null) : null
+  # @section services.waf.enabled end
 
   logging_config = var.cloudfront_enable_logging ? {
     bucket          = "${var.cloudfront_logging_bucket}.s3.amazonaws.com"


### PR DESCRIPTION
## Problem
Enabling CloudFront with WAF disabled generated invalid Terraform: `cloudfront.tf` referenced `aws_wafv2_web_acl.waf` unconditionally, but `waf.tf`'s resource is `@section`-guarded out when WAF is off. `try()` does not help — Terraform resolves the reference at parse/validate time, so `terraform validate` failed with *Reference to undeclared resource*.

Reproduced on real prod-generated output (a normal wizard session with CloudFront on, WAF off) — the wizard did not force WAF, so a user could ship broken IaC.

## Fix
Wrap the `web_acl_id` line in a nested `@section services.waf.enabled` block, so the WAF reference is only emitted when the WAF section is generated. With WAF off the line is commented out and the CloudFront module falls back to its default (no web ACL).

## Verification
Regenerated via Injecto + `terraform validate`:
- WAF **off** + CloudFront on → `web_acl_id` commented → **Success! The configuration is valid.**
- WAF **on** + CloudFront on → `web_acl_id` active, references the real WAF → **Success!**

Fixes `000_INT_DOG_OpenPrime-155`.