### PR TITLE
fix(iam): use full role names for IRSA roles to avoid AWS 38-char name_prefix limit

### DIFF
--- a/templates/terraform/aws/eks.tf
+++ b/templates/terraform/aws/eks.tf
@@ -13,6 +13,7 @@ module "ebs_csi_irsa_role" {
   version = "~> 6.2"
 
   name                  = "${local.cluster_name}-ebs-csi"
+  use_name_prefix       = false
   attach_ebs_csi_policy = true
 
   oidc_providers = {
@@ -28,6 +29,7 @@ module "efs_csi_irsa_role" {
   version = "~> 6.2"
 
   name                  = "${local.cluster_name}-efs-csi"
+  use_name_prefix       = false
   attach_efs_csi_policy = true
 
   oidc_providers = {
@@ -43,6 +45,7 @@ module "vpc_cni_irsa_role" {
   version = "~> 6.2"
 
   name                  = "${local.cluster_name}-vpc-cni"
+  use_name_prefix       = false
   attach_vpc_cni_policy = true
   vpc_cni_enable_ipv4   = true
 
@@ -59,6 +62,7 @@ module "alb_controller_irsa_role" {
   version = "~> 6.2"
 
   name                                   = "${local.cluster_name}-aws-lb-controller"
+  use_name_prefix                        = false
   attach_load_balancer_controller_policy = true
 
   oidc_providers = {
@@ -74,6 +78,7 @@ module "external_dns_irsa_role" {
   version = "~> 6.2"
 
   name                       = "${local.cluster_name}-external-dns"
+  use_name_prefix            = false
   attach_external_dns_policy = true
 
   external_dns_hosted_zone_arns = ["arn:aws:route53:::hostedzone/*"]

--- a/templates/terraform/aws/monitoring.tf
+++ b/templates/terraform/aws/monitoring.tf
@@ -30,7 +30,8 @@ module "loki_role" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts"
   version = "~> 6.2"
 
-  name = local.general_name
+  name            = local.general_name
+  use_name_prefix = false
 
   policies = {
     LokiPolicy = module.loki_policy.arn


### PR DESCRIPTION
## Problem
`terraform plan` failed for generated environments with IRSA roles whose computed name exceeds AWS's 38-character `name_prefix` limit:
- `<cluster>-aws-lb-controller` (44), `<cluster>-external-dns` (39), `<account-id>-<cluster>-loki` (44).

The `iam-role-for-service-accounts` module defaults to `use_name_prefix = true`, so the `name` is used as a `name_prefix` (AWS limit **38**), not a full role name (limit **64**). Loki is the most fragile — its name embeds the 12-char AWS account id.

This only surfaces at `plan` time (a provider-side validation), so `terraform validate` does not catch it.

## Fix
Set `use_name_prefix = false` on all six IRSA role module calls (ebs-csi, efs-csi, vpc-cni, aws-lb-controller, external-dns, loki). The `name` then becomes the full IAM role name (64-char limit). The previously-failing names (43/38/43 without the prefix dash) all fit comfortably under 64.

## Verification
- Regenerated via Injecto + `terraform validate` → **Success!** (no regression); all six roles emit `use_name_prefix = false`.
- Fix is deterministic by the AWS provider schema (role `name` ≤ 64 vs `name_prefix` ≤ 38) and the observed lengths from the original failing plan.
- Note: a real `terraform plan` re-run (needs AWS creds) is recommended as a final confirmation.

Fixes `000_INT_DOG_OpenPrime-156`.