### PR TITLE
fix(templates): parameterize Terraform state key for per-environment scoping

### DIFF
--- a/templates/terraform/aws/_config.tf
+++ b/templates/terraform/aws/_config.tf
@@ -5,7 +5,8 @@ terraform {
   backend "s3" {
     # @param terraformBackend.bucketName
     bucket = "my-terraform-state-bucket"
-    key    = "aws.tfstate"
+    # @param terraformBackend.awsStateKey
+    key = "aws.tfstate"
     # @param region
     region = "eu-west-1"
     # @param terraformBackend.encrypt

--- a/templates/terraform/kubernetes/_config.tf
+++ b/templates/terraform/kubernetes/_config.tf
@@ -5,7 +5,8 @@ terraform {
   backend "s3" {
     # @param terraformBackend.bucketName
     bucket = "my-terraform-state-bucket"
-    key    = "kubernetes.tfstate"
+    # @param terraformBackend.kubernetesStateKey
+    key = "kubernetes.tfstate"
     # @param region
     region = "eu-west-1"
     # @param terraformBackend.encrypt

--- a/templates/terraform/kubernetes/_data.tf
+++ b/templates/terraform/kubernetes/_data.tf
@@ -5,7 +5,8 @@ data "terraform_remote_state" "aws" {
   config = {
     # @param terraformBackend.bucketName
     bucket = "my-terraform-state-bucket"
-    key    = "aws.tfstate"
+    # @param terraformBackend.awsStateKey
+    key = "aws.tfstate"
     # @param region
     region = "eu-west-1"
     # @param terraformBackend.encrypt


### PR DESCRIPTION
## What
Parameterize the S3 backend `key` in the generated Terraform so the backend can scope it per environment:
- `terraform/aws/_config.tf` → `# @param terraformBackend.awsStateKey`
- `terraform/kubernetes/_config.tf` → `# @param terraformBackend.kubernetesStateKey`
- `terraform/kubernetes/_data.tf` (remote-state read) → `# @param terraformBackend.awsStateKey` (same key the aws layer writes)

Uses the existing (path-only) `@param` format, so deployed Injecto handles it; when the backend omits the value, the literal (`aws.tfstate`) remains as a fallback. `terraform fmt` clean.

## Why
The state key was a hardcoded `aws.tfstate`, so a deleted-and-recreated environment reusing the same bucket silently adopted stale state and planned destroying live infra. The companion backend PR (`fix/unique-tf-state-key`) sends `env/<id>/aws.tfstate` for new environments and the legacy literal for already-deployed ones. Confirmed in the 2026-07-11 readiness audit. Part of OP-212.

## Verified
Ran Injecto `process_files` on these templates with a scoped payload → `aws/_config.tf: key = "env/<id>/aws.tfstate"`, `kubernetes/_config.tf: key = "env/<id>/kubernetes.tfstate"`, `kubernetes/_data.tf: key = "env/<id>/aws.tfstate"`.
